### PR TITLE
Fix AutoLayout errors

### DIFF
--- a/EasyDialogs/input controls/CustomEditorInput.swift
+++ b/EasyDialogs/input controls/CustomEditorInput.swift
@@ -60,6 +60,7 @@ open class CustomEditorInput<VALUE>: ValueInput<VALUE, NSView> {
         button.image = buttonIcon ?? Images.get(name: "pencil.png")
         
         let container = NSView()
+        container.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(textField)
         container.addSubview(button)
         

--- a/EasyDialogs/input controls/ValueInput.swift
+++ b/EasyDialogs/input controls/ValueInput.swift
@@ -37,6 +37,7 @@ open class InputView: NSView {
     init(name: String) {
         self.name = name
         super.init(frame: NSRect(x: 0, y: 0, width: 100, height: 90))
+        self.translatesAutoresizingMaskIntoConstraints = false
     }
     
     required public init?(coder: NSCoder) {

--- a/EasyDialogs/util/NSTextView+Labels.swift
+++ b/EasyDialogs/util/NSTextView+Labels.swift
@@ -34,6 +34,7 @@ extension NSTextField {
     
     public static func createLabel(_ text: String? = nil) -> NSTextField {
         let view = NSTextField()
+        view.translatesAutoresizingMaskIntoConstraints = false
         view.isBezeled = false
         view.drawsBackground = false
         view.isEditable = false

--- a/EasyDialogs/window/Bool+Ask.swift
+++ b/EasyDialogs/window/Bool+Ask.swift
@@ -101,6 +101,7 @@ private class ButtonsFormWindow: ModalWindow {
         
         let contentView = self.window!.contentView!
         let wrapperView = NSView()
+        wrapperView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(wrapperView)
         constrain(contentView, wrapperView) { content, wrapper in
             wrapper.edges == content.edges
@@ -109,6 +110,7 @@ private class ButtonsFormWindow: ModalWindow {
         
         let label = NSTextField.createMultilineLabel(headerText)
         let buttonsView = NSView()
+        buttonsView.translatesAutoresizingMaskIntoConstraints = false
         wrapperView.addSubview(label)
         wrapperView.addSubview(buttonsView)
         

--- a/EasyDialogs/window/FormWindow.swift
+++ b/EasyDialogs/window/FormWindow.swift
@@ -152,6 +152,7 @@ extension FormWindow {
         
         let contentView = self.window!.contentView!
         let wrapperView = NSView()
+        wrapperView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(wrapperView)
         constrain(contentView, wrapperView) { content, wrapper in
             wrapper.edges == content.edges
@@ -181,9 +182,11 @@ extension FormWindow {
     private func createStackView() -> NSView {
         
         let stack = NSStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
         stack.orientation = .vertical
         stack.spacing = 1
         let scroll = NSScrollView()
+        scroll.translatesAutoresizingMaskIntoConstraints = false
         scroll.documentView = stack
         scroll.drawsBackground = false
         scroll.borderType = .noBorder
@@ -209,8 +212,10 @@ extension FormWindow {
     private func createHeader(headerText: String?) -> NSView {
         
         let header = NSView()
+        header.translatesAutoresizingMaskIntoConstraints = false
         if let headerText = headerText {
             let label = NSTextField.createMultilineLabel(headerText)
+            label.translatesAutoresizingMaskIntoConstraints = false
             header.addSubview(label)
             constrain(header, label) { header, label in
                 label.top == header.top + contentViewInternalPadding
@@ -240,6 +245,7 @@ extension FormWindow {
         self.errorLabel = errorLabel
         
         let footer = NSView()
+        footer.translatesAutoresizingMaskIntoConstraints = false
         footer.addSubview(OKButton)
         footer.addSubview(cancelButton)
         footer.addSubview(errorLabel)


### PR DESCRIPTION
For all views created in code and managed by AutoLayout we need to set `translatesAutoresizingMaskIntoConstraints = false`. Otherwise it adds implicit constrains which most of the time results in AutoLayout issues.